### PR TITLE
binderhub: 1a76d5f...f565958

### DIFF
--- a/gesisbinder/gesisbinder/requirements.yaml
+++ b/gesisbinder/gesisbinder/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
  - name: binderhub
-   version: 0.2.0-1a76d5f
+   version: 0.2.0-f565958
    repository: https://jupyterhub.github.io/helm-chart

--- a/gesisbinder/templates/loading.html
+++ b/gesisbinder/templates/loading.html
@@ -30,7 +30,7 @@ div#loader-text {
 
 <div id="loader"></div>
 <div id="loader-text">
-	<p>Loading your Binder...</p>
+	<p class="launching">Launching your Binder...</p>
 </div>
 <div id="loader-links">
   <p class="text-center">New to Binder? Check out the <a target="_blank" href="https://mybinder.readthedocs.io/en/latest/">Binder Documentation</a> for more information</p>


### PR DESCRIPTION
This is a binderhub version bump. See the link below for a diff of new changes:

https://github.com/jupyterhub/binderhub/compare/1a76d5f...f565958 

Associated PRs:
- [MRG] Add more loading messages [#924](https://github.com/jupyterhub/binderhub/pull/924)
- [MRG] Automatically open the log while building a repository [#923](https://github.com/jupyterhub/binderhub/pull/923)
- adding help text loop to loading page [#917](https://github.com/jupyterhub/binderhub/pull/917)
- Fixes and tests for git unresolved ref support [#921](https://github.com/jupyterhub/binderhub/pull/921)
 

https://github.com/jupyterhub/mybinder.org-deploy/compare/8d346cd920d344662cce39d24984cdc8bf923b58...5eacf440faf920158e7cdd094072302060ad71fa